### PR TITLE
Add Geckodriver path to firefox config

### DIFF
--- a/src/schematics/nightwatch/files/nightwatch.conf.js.template
+++ b/src/schematics/nightwatch/files/nightwatch.conf.js.template
@@ -90,7 +90,7 @@ module.exports = {
       },
       webdriver: {
         start_process: true,
-        server_path: '',
+        server_path: './node_modules/.bin/geckodriver',
         cli_args: [
           // very verbose geckodriver logs
           // '-vv'


### PR DESCRIPTION
Add path to include the workaround mentioned in:
https://github.com/nightwatchjs/nightwatch-schematics/issues/27#issuecomment-1593223738