### PR TITLE
Add serial and reuse-browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nightwatch/schematics",
-  "version": "1.2.1",
+  "version": "1.2.1-1",
   "description": "Adds Nightwatch to an existing Angular CLI project",
   "scripts": {
     "build": "tsc -p tsconfig.json",

--- a/src/builders/nightwatch/index.ts
+++ b/src/builders/nightwatch/index.ts
@@ -26,6 +26,8 @@ async function runNightwatch(
     'output',
     'headless',
     'verbose',
+    'serial',
+    'reuse-browser',
   ];
 
   const NightwatchLauncher = path.join(process.cwd(), 'node_modules', '.bin', 'nightwatch');

--- a/src/builders/nightwatch/schema.json
+++ b/src/builders/nightwatch/schema.json
@@ -74,6 +74,16 @@
       "description": "Shows extended selenium command logging during the session",
       "default": false
     },
+    "serial": {
+      "type": "boolean",
+      "description": "Run tests sequentially",
+      "default": false
+    },
+    "reuse-browser": {
+      "type": "boolean",
+      "description": "Reuse the browser session, requires serial",
+      "default": false
+    },
     "devServerTarget": {
       "type": "string",
       "description": "Dev server target to run tests against."


### PR DESCRIPTION
Add these missing options. Useful if you have a complex ui with tests dependent on the data used in previous tests